### PR TITLE
Drewby no shortparam

### DIFF
--- a/src/Models/parseBash.tsx
+++ b/src/Models/parseBash.tsx
@@ -282,7 +282,6 @@ export class ParseBash {
                 if (line.substring(0, 1) === "-") // we have a parameter!
                 {
                     const paramTokens: string[] = this.splitByTwoStrings(line, " ", "|");
-                    console.log(line.indexOf("|"));
                     if (line.indexOf("|")<0) 
                     { 
                         paramTokens.unshift("-"); // there is no short parameter, so add token 

--- a/src/Models/parseBash.tsx
+++ b/src/Models/parseBash.tsx
@@ -282,6 +282,11 @@ export class ParseBash {
                 if (line.substring(0, 1) === "-") // we have a parameter!
                 {
                     const paramTokens: string[] = this.splitByTwoStrings(line, " ", "|");
+                    console.log(line.indexOf("|"));
+                    if (line.indexOf("|")<0) 
+                    { 
+                        paramTokens.unshift("-"); // there is no short parameter, so add token 
+                    }
                     let description: string = "";
                     for (let i = 3; i < paramTokens.length; i++) {
                         description += paramTokens[i] + " ";

--- a/src/Models/scriptModel.ts
+++ b/src/Models/scriptModel.ts
@@ -399,8 +399,11 @@ export class ScriptModel {
 
                 //
                 //  OPTIONS, LONGOPTS
-                let colon: string = (param.shortParameter && param.requiresInputString) ? ":" : "";
-                shortOptions += `${param.shortParameter}${colon}`
+                let colon: string = (param.requiresInputString) ? ":" : "";
+                if (param.shortParameter) 
+                {
+                    shortOptions += `${param.shortParameter}${colon}`
+                }
                 longOptions += `${param.longParameter}${colon},`
 
                 // input Case

--- a/src/Models/scriptModel.ts
+++ b/src/Models/scriptModel.ts
@@ -386,8 +386,10 @@ export class ScriptModel {
                 //
                 // usage
                 let required: string = (param.requiredParameter) ? "Required    " : "Optional    ";
-                usageLine += `-${param.shortParameter}|--${param.longParameter} `
-                usageInfo += `${this.Tabs(1)}echo \" -${param.shortParameter} | --${padEnd(param.longParameter, longestLongParameter, " ")} ${required} ${param.description}\"${nl}`
+                let shortUsageLine: string = (param.shortParameter) ? `-${param.shortParameter}|` : ``;
+                usageLine += `${shortUsageLine}--${param.longParameter} `
+                let shortUsageInfo: string = (param.shortParameter) ? `-${param.shortParameter} |` : `    `;
+                usageInfo += `${this.Tabs(1)}echo \" ${shortUsageInfo} --${padEnd(param.longParameter, longestLongParameter, " ")} ${required} ${param.description}\"${nl}`
 
                 //
                 // the  echoInput function
@@ -397,7 +399,7 @@ export class ScriptModel {
 
                 //
                 //  OPTIONS, LONGOPTS
-                let colon: string = (param.requiresInputString) ? ":" : "";
+                let colon: string = (param.shortParameter && param.requiresInputString) ? ":" : "";
                 shortOptions += `${param.shortParameter}${colon}`
                 longOptions += `${param.longParameter}${colon},`
 


### PR DESCRIPTION
### Reason
Adding an option to not have a shortparam for some parameters.  In a script with lots of parameters (especially with similar long names grouped by a prefix), there is not an obvious shortparam name to assign.  Example, look at  grep --help

* Updated usage output to align columns correctly when no short parameter
* Don't add a colon when short parameter doesn't exist
* Handle a missing short parameter when parsing an incoming bash file

### Example new usage output for my script
```
 -t | --target-device          Required     The block device to write raspbian image to.
 -r | --raspbian-image         Optional     Compressed (zip) raspbian OS image.
 -s | --sha-raspbian           Optional     SHA value to validate the raspbian OS image file.
 -h | --hostname               Required     Hostname of the new node
      --external-static-ip     Optional     External static IP address (used for master wlan0 only)
      --external-gateway       Optional     External router address (used for master wlan0 only)
      --external-dns           Optional     External name server (DNS) address (used for master wlan0 only)
 -m | --master                 Optional     Configure the master node (default is to configure slave nodes)
 -z | --zsh                    Optional     Install ZSH shell (and oh-my-zsh) on the node as default shell
      --internal-static-ip     Optional     Internal network static IP address (for private kube network)
      --internal-gateway       Optional     Internal network default gateway (for slave nodes only)
      --internal-dns           Optional     Internal network name server (DNS) address (for slave nodes only)
 -i | --input-file             Optional     the name of the input file. pay attention to /home/drewby/src/kubepi when setting this
```


